### PR TITLE
Fix broken headings in Markdown files

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -1,19 +1,19 @@
 ## ChangeLog
-###0.8.8 -> 0.8.9
+### 0.8.8 -> 0.8.9
 Client now separated in another npm package. use npm install socket.io-rpc-client to get it.
-###0.6.9 -> 0.7.0
+### 0.6.9 -> 0.7.0
 Now only usable with commonJS compatible module loader. I strongly advise to use systemJS module loader in the browser.
-###0.5.4 -> 0.6.0
+### 0.5.4 -> 0.6.0
 More reasonable public API refactor, which now requires you to connect before you can load channels
-###0.3.18 -> 0.3.19
+### 0.3.18 -> 0.3.19
 Finally a proper version of socket.io, so I removed temporary hacks from client channels instantiation, updated express.js peerDependency to ~4
-###0.3.12 -> 0.3.13
+### 0.3.12 -> 0.3.13
 channel is now injected into the controller, not put on scope as a property as before, be aware when updating
-###0.3.9 -> 0.3.10
+### 0.3.9 -> 0.3.10
 Switched once again promise library, now to Bluebird for even better performance, I doubt that any faster promise implementation will replace it any time in next year, so bluebird will last longer than the last two
-###0.2.5 -> 0.3.0
+### 0.2.5 -> 0.3.0
 Synchronous resolution of a call can be now also rejected without need to create and reject a promise by simply returning an instance of Error
-###0.1.3 -> 0.1.4
+### 0.1.3 -> 0.1.4
 Added a directive to angularJS client to make instantiating a controller with rpc channel less of a chore
-###0.0.8 -> 0.0.9
+### 0.0.8 -> 0.0.9
 Switched from Q to when.js for better performance

--- a/readme.md
+++ b/readme.md
@@ -15,7 +15,7 @@ With socket.io-rpc, you just expose a tree of functions and then call those, soc
 
 Because they are much more flexible abstraction for running tasks over the network. Trying to map all possible errors and their causes to available HTTP codes is not always straightforward and requires a lot of experience.
 
-#Simple example
+# Simple example
 Folder with example can be run after installing all dependencies like this in the simple-example folder:
 
     npm install //this runs jspm install too
@@ -24,12 +24,12 @@ Then run it from git repo root:
 
     node simple-example/server
 
-###With authentication (server)
+### With authentication (server)
 
 Set authentication normally as you would with [socket.io](http://socket.io/docs/migrating-from-0-9/#authentication-differences).
 
 
-###With authentication (browser)
+### With authentication (browser)
 
 Send your auth token with the backend connect method(the one that is exported from the module).
 


### PR DESCRIPTION
GitHub changed the way Markdown headings are parsed, so this change fixes it.

See [bryant1410/readmesfix](https://github.com/bryant1410/readmesfix) for more information.

Tackles bryant1410/readmesfix#1
